### PR TITLE
Handle long fix target lists via sidecar file

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ If the output directory already contains files, Michael asks for confirmation be
 	- Bash: `templates/fix-script.sh.template`
 - Script templates support placeholders: `[[issueDetails]]`, `[[fileList]]`, and `[[samples]]` (plus `[[rank]]`, `[[targetFileCount]]`).
 - The Copilot command line is hardcoded in each template (`$Prompt` in PowerShell, `$prompt` in Bash).
+- When a ranked issue has more than `20` target files, `[[fileList]]` is replaced with a reference to `fix-rank-<n>-files.txt`, and the full list is written to that file.
 
 Example `michael.config.json`:
 

--- a/src/Michael.Fixes/TemplateFixScriptGenerator.cs
+++ b/src/Michael.Fixes/TemplateFixScriptGenerator.cs
@@ -10,6 +10,7 @@ public sealed partial class TemplateFixScriptGenerator : IFixScriptGenerator
 {
     private const int MaxSamplesPerIssue = 2;
     private const int ContextLineRadius = 2;
+    private const int MaxInlineFileListEntries = 20;
     private const string DefaultScriptTemplate = """
 # Michael generated fix script
 # Rank: [[rank]]
@@ -75,8 +76,9 @@ finally {
             var fileName = $"fix-rank-{issue.Rank}{resolvedScriptExtension}";
             var fullPath = Path.Combine(outputDirectory, fileName);
             var targetLocations = BuildTargetLocations(issue.Files);
+            var originalLocations = BuildOriginalLocations(issue.Files);
             var issueDetails = BuildIssueDetails(issue);
-            var fileList = BuildFileList(targetLocations);
+            var fileList = BuildFileList(outputDirectory, issue.Rank, targetLocations, originalLocations);
             var samples = BuildSamplesSection(issue.Files);
             var script = BuildScript(
                 issue.Rank,
@@ -162,7 +164,11 @@ finally {
         return builder.ToString().TrimEnd();
     }
 
-    private static string BuildFileList(IReadOnlyList<string> targetLocations)
+    private static string BuildFileList(
+        string outputDirectory,
+        int rank,
+        IReadOnlyList<string> targetLocations,
+        IReadOnlyList<string> originalLocations)
     {
         var builder = new StringBuilder();
 
@@ -172,9 +178,49 @@ finally {
             return builder.ToString();
         }
 
+        if (targetLocations.Count > MaxInlineFileListEntries)
+        {
+            var longListFileName = $"fix-rank-{rank}-files.txt";
+            var longListPath = Path.Combine(outputDirectory, longListFileName);
+            var longListContent = BuildLongFileListContent(targetLocations, originalLocations);
+            File.WriteAllText(longListPath, longListContent);
+
+            builder.Append($"- Target file list is too long ({targetLocations.Count} files). See {longListFileName}.");
+            return builder.ToString();
+        }
+
         foreach (var location in targetLocations)
         {
             builder.AppendLine($"- {location}");
+        }
+
+        return builder.ToString().TrimEnd();
+    }
+
+    private static string BuildLongFileListContent(
+        IReadOnlyList<string> targetLocations,
+        IReadOnlyList<string> originalLocations)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# Michael generated file list");
+        builder.AppendLine($"# Target files: {targetLocations.Count}");
+        builder.AppendLine();
+        builder.AppendLine("Target files (unique):");
+
+        foreach (var location in targetLocations)
+        {
+            builder.AppendLine($"- {location}");
+        }
+
+        if (originalLocations.Count > 0)
+        {
+            builder.AppendLine();
+            builder.AppendLine("Original log locations (line/column when available):");
+
+            foreach (var location in originalLocations)
+            {
+                builder.AppendLine($"- {location}");
+            }
         }
 
         return builder.ToString().TrimEnd();
@@ -276,6 +322,16 @@ finally {
             .Where(path => !string.IsNullOrWhiteSpace(path))
             .Distinct(StringComparer.Ordinal)
             .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static IReadOnlyList<string> BuildOriginalLocations(IReadOnlyList<string> locations)
+    {
+        return locations
+            .Where(location => !string.IsNullOrWhiteSpace(location) && location != "(no-file)")
+            .Select(location => location.Trim())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(location => location, StringComparer.Ordinal)
             .ToArray();
     }
 

--- a/tests/Michael.Tests/TemplateFixScriptGeneratorTests.cs
+++ b/tests/Michael.Tests/TemplateFixScriptGeneratorTests.cs
@@ -420,6 +420,60 @@ copilot -i "agent --prompt $Prompt"
         }
     }
 
+    [Fact]
+    public void Generate_WithMoreThanTwentyTargetFiles_WritesExternalFileListAndReferencesIt()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"michael-fixes-long-list-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var generator = new TemplateFixScriptGenerator();
+            var locations = Enumerable.Range(1, 21)
+                .Select(index => Path.Combine(tempDir, $"File{index:00}.cs") + $"({index},1)")
+                .ToArray();
+
+            var rankedIssues = new[]
+            {
+                new RankedIssue(
+                    Rank: 1,
+                    Key: "LONGFILELIST",
+                    Message: "Many files",
+                    Files: locations,
+                    Severity: "warning",
+                    Frequency: 1,
+                    Confidence: 0.90,
+                    Score: 200,
+                    Explanation: "Long file list sample")
+            };
+
+            var filesByRank = generator.Generate(tempDir, rankedIssues);
+            var scriptPath = Path.Combine(tempDir, filesByRank[1]);
+            var script = File.ReadAllText(scriptPath);
+
+            Assert.Contains("# Target files: 21", script, StringComparison.Ordinal);
+            Assert.Contains("Target file list is too long (21 files). See fix-rank-1-files.txt.", script, StringComparison.Ordinal);
+            Assert.DoesNotContain($"- {Path.Combine(tempDir, "File01.cs")}", script, StringComparison.Ordinal);
+
+            var listFilePath = Path.Combine(tempDir, "fix-rank-1-files.txt");
+            Assert.True(File.Exists(listFilePath));
+
+            var listFileContent = File.ReadAllText(listFilePath);
+            Assert.Contains("# Michael generated file list", listFileContent, StringComparison.Ordinal);
+            Assert.Contains("# Target files: 21", listFileContent, StringComparison.Ordinal);
+            Assert.Contains($"- {Path.Combine(tempDir, "File01.cs")}", listFileContent, StringComparison.Ordinal);
+            Assert.Contains($"- {Path.Combine(tempDir, "File01.cs")}(1,1)", listFileContent, StringComparison.Ordinal);
+            Assert.Contains("Original log locations (line/column when available):", listFileContent, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+
     private static int CountOccurrences(string text, string value)
     {
         var count = 0;


### PR DESCRIPTION
## Summary
- externalize long fix target lists when an issue affects more than 20 files
- keep generated script prompts concise by referencing fix-rank-<n>-files.txt
- include original log locations (line/column when available) in the sidecar file
- add unit test coverage for the >20 files behavior
- document the behavior in README

## Validation
- dotnet test tests/Michael.Tests/Michael.Tests.csproj --nologo

Closes #8