### PR TITLE
Hide Fix section in analysis-only summaries

### DIFF
--- a/src/Michael.Cli/FileReportWriter.cs
+++ b/src/Michael.Cli/FileReportWriter.cs
@@ -78,7 +78,7 @@ public sealed class FileReportWriter : IReportWriter
                 : BuildFilesDetailsMarkdown(issue.Files);
 
             var details = $"<strong>Error Message</strong><br/>{EscapePipe(Truncate(issue.Message, 90))}<br/>{filesDetails}";
-            if (string.IsNullOrWhiteSpace(metadata.FixesZipFile))
+            if (ShouldIncludeFixDetails(metadata, issue.Rank, fixScriptFileNamesByRank))
             {
                 var fixDetails = BuildFixDetailsMarkdown(issue.Rank, metadata.OutputDirectory, fixScriptFileNamesByRank);
                 details += $"<br/>{fixDetails}";
@@ -211,7 +211,7 @@ public sealed class FileReportWriter : IReportWriter
                     : BuildFilesDetailsHtml(issue.Files);
 
                 var details = $"<strong>Error Message</strong><br/>{HtmlEncode(Truncate(issue.Message, 140))}<br/>{filesDetails}";
-                if (string.IsNullOrWhiteSpace(metadata.FixesZipFile))
+                if (ShouldIncludeFixDetails(metadata, issue.Rank, fixScriptFileNamesByRank))
                 {
                     var fixDetails = BuildFixDetailsHtml(issue.Rank, metadata.OutputDirectory, fixScriptFileNamesByRank);
                     details += $"<br/>{fixDetails}";
@@ -368,6 +368,19 @@ public sealed class FileReportWriter : IReportWriter
         }
 
         return string.Join(", ", detectedTools);
+    }
+
+    private static bool ShouldIncludeFixDetails(
+        ReportMetadata metadata,
+        int rank,
+        IReadOnlyDictionary<int, string>? fixScriptFileNamesByRank)
+    {
+        if (metadata.AnalyseOnly || !string.IsNullOrWhiteSpace(metadata.FixesZipFile))
+        {
+            return false;
+        }
+
+        return fixScriptFileNamesByRank is not null && fixScriptFileNamesByRank.ContainsKey(rank);
     }
 
     private static string BuildFixDetailsHtml(

--- a/tests/Michael.Tests/CliValidationTests.cs
+++ b/tests/Michael.Tests/CliValidationTests.cs
@@ -106,6 +106,7 @@ public class CliValidationTests
             var summaryPath = Path.Combine(outputDir, "summary.md");
             var summary = File.ReadAllText(summaryPath);
             Assert.Contains("- Detected tools/frameworks: .NET SDK 9.0.114, .NET, C#", summary, StringComparison.Ordinal);
+            Assert.DoesNotContain("<strong>Fix</strong>", summary, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/Michael.Tests/FileReportWriterTests.cs
+++ b/tests/Michael.Tests/FileReportWriterTests.cs
@@ -20,7 +20,7 @@ public class FileReportWriterTests
                 "1.0.0-test",
                 "input.log",
                 tempDir,
-                true,
+                false,
                 2,
                 10,
                 2,
@@ -75,6 +75,13 @@ public class FileReportWriterTests
             var expectedZipUri = $"vscode://file/{string.Join('/', Path.Combine(tempDir, "fixes.zip").Replace('\\', '/').Split('/').Select(Uri.EscapeDataString))}";
             Assert.Contains($"- Fixes archive: <a href=\"{expectedZipUri}\" target=\"_blank\" rel=\"noopener noreferrer\">fixes.zip</a>", markdown, StringComparison.Ordinal);
             Assert.Contains($"<li><strong>Fixes archive:</strong> <a href=\"{expectedZipUri}\" target=\"_blank\" rel=\"noopener noreferrer\">fixes.zip</a></li>", html, StringComparison.Ordinal);
+            Assert.DoesNotContain("<strong>Fix</strong>", markdown, StringComparison.Ordinal);
+            Assert.DoesNotContain("<strong>Fix</strong>", html, StringComparison.Ordinal);
+
+            writer.Write(tempDir, metadata with { AnalyseOnly = true }, ranked);
+
+            markdown = File.ReadAllText(summaryPath);
+            html = File.ReadAllText(htmlPath);
             Assert.DoesNotContain("<strong>Fix</strong>", markdown, StringComparison.Ordinal);
             Assert.DoesNotContain("<strong>Fix</strong>", html, StringComparison.Ordinal);
 


### PR DESCRIPTION
## Summary
- hide per-issue  details when running with
- keep  details visible only when a generated fix file exists for that rank
- preserve existing zip behavior (metadata shows , row-level  is hidden)

## Tests
- dotnet test tests/Michael.Tests/Michael.Tests.csproj --nologo

Closes #10