### PR TITLE
Fix release workflow to generate release notes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,13 @@ jobs:
           grep -Fq 'michael-<tag>-osx-arm64.tar.gz' "$readme"
           grep -Fq 'michael-<tag>-win-x64.zip' "$readme"
 
+      - name: Validate release notes generation is enabled
+        run: |
+          set -euo pipefail
+          workflow=".github/workflows/release.yml"
+
+          grep -Fq 'generate_release_notes: true' "$workflow"
+
       - name: Clean test results directory
         run: |
           rm -rf TestResults/current

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,4 +201,5 @@ jobs:
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
+          generate_release_notes: true
           files: artifacts/packages/*


### PR DESCRIPTION
# Summary
- enable generated release notes when attaching assets in release workflow
- add PR workflow validation to ensure release notes generation remains enabled
 
## Why
Fixes #11. Release notes were not generated during release builds because `softprops/action-gh-release` was used without `generate_release_notes: true`.

## Changes
- `.github/workflows/release.yml`
  - added `generate_release_notes: true` under `softprops/action-gh-release`
- `.github/workflows/pull-request.yml`
  -  added a guard step that asserts release notes generation is enabled
  
## Validation
- branch pushed successfully: `fix/issue-11-release-notes`
- workflow config contains expected release notes setting

Closes #11 